### PR TITLE
Change createReducer to createSlice.

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,7 +271,7 @@ export const fetchCats = createAsyncThunk("cats/fetchCats", () => {
 Next, to add this to our reducer:
 
 ```js
-const catsSlice = createReducer(
+const catsSlice = createSlice({
   name: "cats",
   initialState,
   reducers: {
@@ -288,7 +288,7 @@ const catsSlice = createReducer(
       state.status = "idle";
     },
   },
-)
+})
 ```
 
 To recap what the code above is doing:


### PR DESCRIPTION
The thing inside was so familiar with the objects that we were passing in createSlice, also the fact that we imported the createSlice with createAsyncThunk together and got this example but the example didn't have the createSlice in it was kinda felt weird and made me think that that was a typo. I'm not sure but in case it is, I wanted to do this pull request and save some time for you people. Have a great day! :)